### PR TITLE
Changing account update method from POST to PUT

### DIFF
--- a/lib/routes/v2.js
+++ b/lib/routes/v2.js
@@ -2,7 +2,7 @@ exports.accounts = {
 	list: ['/v2/accounts', 'GET'],
 	get: ['/v2/accounts/:account_code', 'GET'],
 	create: ['/v2/accounts', 'POST'],
-	update: ['/v2/accounts/:account_code', 'POST'],
+	update: ['/v2/accounts/:account_code', 'PUT'],
 	close: ['/v2/accounts/:account_code', 'DELETE'],
 	reopen: ['/v2/accounts/:account_code/reopen', 'PUT']
 }


### PR DESCRIPTION
Using POST method results in a 404 from recurly for account updates. It must use method PUT
