### PR TITLE
Add root to xml params

### DIFF
--- a/lib/jsToXml.js
+++ b/lib/jsToXml.js
@@ -1,8 +1,16 @@
 var xml2js = require('xml2js');
 var builder = new xml2js.Builder();
 
-function jsToXml(input) {
-	return builder.buildObject(input);
+function jsToXml(input, rootName) {
+	if (rootName) {
+		const wrappedInput = {};
+		wrappedInput[rootName] = input;
+		return builder.buildObject(wrappedInput);
+	}
+	else {
+		const a = input;
+		return builder.buildObject(input);
+	}
 }
 
 module.exports = jsToXml;

--- a/lib/recurly.js
+++ b/lib/recurly.js
@@ -17,10 +17,10 @@
         t.request(utils.addParams(routes.accounts.get, {account_code: accountcode}), callback);
       },
       create: function(details, callback){
-        t.request(routes.accounts.create, callback, jsToXml(details));
+        t.request(routes.accounts.create, callback, jsToXml(details, 'account'));
       },
       update: function(accountcode, details, callback){
-        t.request(utils.addParams(routes.accounts.update, {account_code: accountcode}), callback, jsToXml(details));
+        t.request(utils.addParams(routes.accounts.update, {account_code: accountcode}), callback, jsToXml(details, 'account'));
       },
       close: function(accountcode, callback){
         t.request(utils.addParams(routes.accounts.close, {account_code: accountcode}), callback);
@@ -35,7 +35,7 @@
         t.request(utils.addParams(routes.adjustments.get, {account_code: accountcode}), callback);
       },
       create: function(accountcode, details, callback){
-        t.request(utils.addParams(routes.adjustments.create, {account_code: accountcode}), callback, jsToXml(details));
+        t.request(utils.addParams(routes.adjustments.create, {account_code: accountcode}), callback, jsToXml(details, 'adjustment'));
       },
       remove: function(uuid, callback){
         t.request(utils.addParams(routes.adjustments.remove, {uuid: uuid}), callback);
@@ -45,7 +45,7 @@
 		//http://docs.recurly.com/api/billing-info
     this.billingInfo = {
       update: function(accountcode, details, callback){
-        t.request(utils.addParams(routes.billingInfo.update, {account_code: accountcode} ), callback, jsToXml(details));
+        t.request(utils.addParams(routes.billingInfo.update, {account_code: accountcode} ), callback, jsToXml(details, 'billing_info'));
       },
       get: function(accountcode, callback){
         t.request(utils.addParams(routes.billingInfo.get, {account_code: accountcode} ), callback);
@@ -64,7 +64,7 @@
         t.request(utils.addParams(routes.coupons.get, {coupon_code: couponcode}), callback);
       },
       create: function(details, callback){
-        t.request(routes.coupons.create, callback, jsToXml(details));
+        t.request(routes.coupons.create, callback, jsToXml(details, 'coupon'));
       },
       deactivate: function(couponcode, callback){
         t.request(utils.addParams(routes.coupons.deactivate, {coupon_code: couponcode}), callback);
@@ -73,7 +73,7 @@
 
     this.couponRedemption = {
       redeem: function(couponcode, details, callback){
-        t.request(utils.addParams(routes.couponRedemption.redeem, {coupon_code: couponcode}), callback, jsToXml(details));
+        t.request(utils.addParams(routes.couponRedemption.redeem, {coupon_code: couponcode}), callback, jsToXml(details, 'redemption'));
       },
       get: function(accountcode, callback){
         t.request(utils.addParams(routes.couponRedemption.get, {account_code: accountcode}), callback);
@@ -101,7 +101,7 @@
         t.request(utils.addParams(routes.invoices.get, {invoice_number: invoicenumber}), callback);
       },
       create: function(accountcode, details, callback){
-        t.request(utils.addParams(routes.invoices.create, {account_code: accountcode}), callback, jsToXml(details));
+        t.request(utils.addParams(routes.invoices.create, {account_code: accountcode}), callback, jsToXml(details, 'invoice'));
       },
       markSuccessful: function(invoicenumber, callback){
         t.request(utils.addParams(routes.invoices.markSuccessful, {invoice_number: invoicenumber}), callback);
@@ -125,10 +125,10 @@
         t.request(utils.addParams(routes.plans.get, {plan_code: plancode}), callback);
       },
       create: function(details, callback){
-        t.request(routes.plans.create, callback, jsToXml(details));
+        t.request(routes.plans.create, callback, jsToXml(details, 'plan'));
       },
       update: function(plancode, details, callback){
-        t.request(utils.addParams(routes.plans.update, {plan_code: plancode}), callback, jsToXml(details));
+        t.request(utils.addParams(routes.plans.update, {plan_code: plancode}), callback, jsToXml(details, 'plan'));
       },
       remove: function(plancode, callback){
         t.request(utils.addParams(routes.plans.remove, {plan_code: plancode}), callback);
@@ -143,7 +143,7 @@
         t.request(utils.addParams(routes.planAddons.get, {plan_code: plancode, addon_code: addoncode}), callback);
       },
       create: function(plancode, details, callback){
-        t.request(utils.addParams(routes.planAddons.create, {plan_code: plancode}), callback, jsToXml(details));
+        t.request(utils.addParams(routes.planAddons.create, {plan_code: plancode}), callback, jsToXml(details, 'add_on'));
       },
       update: function(plancode, addoncode, details, callback){
         t.request(utils.addParams(
@@ -151,7 +151,7 @@
           { plan_code: plancode,
             add_on_code: addoncode
           }),
-        callback, jsToXml(details));
+        callback, jsToXml(details, 'add_on'));
       },
       remove: function(plancode, addoncode, callback){
         t.request(utils.addParams(routes.planAddons.remove, {plan_code: plancode, add_on_code: addoncode}), callback);
@@ -170,10 +170,10 @@
         t.request(utils.addParams(routes.subscriptions.get, {uuid: uuid}), callback);
       },
       create: function(details, callback){
-        t.request(routes.subscriptions.create, callback, jsToXml(details));
+        t.request(routes.subscriptions.create, callback, jsToXml(details, 'subscription'));
       },
       update: function(uuid, details, callback){
-        t.request(utils.addParams(routes.subscriptions.update, {uuid: uuid}), callback, jsToXml(details));
+        t.request(utils.addParams(routes.subscriptions.update, {uuid: uuid}), callback, jsToXml(details, 'subscription'));
       },
       cancel: function(uuid, callback){
         t.request(utils.addParams(routes.subscriptions.cancel, {uuid: uuid}), callback);
@@ -203,7 +203,7 @@
         t.request(utils.addParams(routes.transactions.get, {'id': id}), callback);
       },
       create: function(details, callback){
-        t.request(routes.transactions.create, callback, jsToXml(details));
+        t.request(routes.transactions.create, callback, jsToXml(details, 'transaction',));
       },
       refund: function(id, callback, amount){
         var route = utils.addParams(routes.transactions.refund, {id: id});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,52 @@
+{
+  "name": "node-recurly",
+  "version": "2.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "bindings": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+      "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
+    },
+    "js2xml": {
+      "version": "git://github.com/SocialBro/js2xml.git#07fca5fdc89f518030ca4026d5bc0e6674805fe7",
+      "requires": {
+        "libxmljs": "0.18.0"
+      }
+    },
+    "libxmljs": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/libxmljs/-/libxmljs-0.18.0.tgz",
+      "integrity": "sha1-4pk9zyjk3GDnNIbi22Il3CTRhTE=",
+      "requires": {
+        "bindings": "1.2.1",
+        "nan": "2.3.2"
+      }
+    },
+    "nan": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.2.tgz",
+      "integrity": "sha1-TU7PF+HaTpie+08nPY0AIBytCH4="
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "xml2js": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.18.tgz",
+      "integrity": "sha512-MMUtkwryoXmYoFUBT32tf7vYPHr98h6VtRLVbsjfmS5hqpp/deRMUNLZNQUHEAY4ChwyBEkisDYhH/EP15X6oA==",
+      "requires": {
+        "sax": "1.2.4",
+        "xmlbuilder": "9.0.4"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.4.tgz",
+      "integrity": "sha1-UZy0ymhtAFqEINNJbz8MruzKWA8="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,20 +1,30 @@
-{ "name" : "node-recurly"
-, "description" : "Library for accessing the api for the Recurly recurring billing service."
-, "keywords" : [ "recurly", "e-commerce", "recurring billing" ]
-, "version" : "2.1.0"
-, "homepage" : "https://github.com/robrighter/node-recurly"
-, "author" : "Rob Righter <robrighter@gmail.com> (http://github.com/robrighter)"
-, "contributors" : [ 
-  "Iván Guardado <dev.ivangc@gmail.com> (http://github.com/IvanGuardado)",
-  "Rob Righter <robrighter@gmail.com> (http://github.com/robrighter)"
-  ]
-, "bugs" :
-  { "web" : "https://github.com/robrighter/node-recurly/issues" }
-, "directories" : { "lib" : "./lib" }
-, "main" : "./lib/recurly.js"
-, "dependencies" : {
+{
+  "name": "node-recurly",
+  "description": "Library for accessing the api for the Recurly recurring billing service.",
+  "keywords": [
+    "recurly",
+    "e-commerce",
+    "recurring billing"
+  ],
+  "version": "2.1.1",
+  "homepage": "https://github.com/robrighter/node-recurly",
+  "author": "Rob Righter <robrighter@gmail.com> (http://github.com/robrighter)",
+  "contributors": [
+    "Iván Guardado <dev.ivangc@gmail.com> (http://github.com/IvanGuardado)",
+    "Rob Righter <robrighter@gmail.com> (http://github.com/robrighter)"
+  ],
+  "bugs": {
+    "web": "https://github.com/robrighter/node-recurly/issues"
+  },
+  "directories": {
+    "lib": "./lib"
+  },
+  "main": "./lib/recurly.js",
+  "dependencies": {
     "xml2js": "0.4.18",
     "js2xml": "git://github.com/SocialBro/js2xml"
-}
-, "engines" : { "node" : ">= 0.4" }
+  },
+  "engines": {
+    "node": ">= 0.4"
+  }
 }

--- a/test/jsToXml_spec.js
+++ b/test/jsToXml_spec.js
@@ -4,7 +4,39 @@ const assert = require('assert');
 const jsToXml = require('../lib/jsToXml');
 
 describe('JS to XML converter', () => {
-	
+
+	it('should build an add a custom root to the final xml correctly', () => {
+		const input = {
+			plan_code: 'ac5_ct20_bt500_tm1_c0_p1005',
+		  name: 'Custom Plan',
+		  unit_amount_in_cents: { USD: '1005', EUR: '854', GBP: '754' },
+		  plan_interval_length: 1,
+		  plan_interval_unit: 'months',
+		  tax_code: 'digital',
+		  success_url: 'https://buy.audiense.com/signup_done?plan={{plan_code}}',
+		  cancel_url: 'https://buy.audiense.com/signup_canceled',
+		  bypass_hosted_confirmation: 'true'
+		};
+		const expected = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<plan>
+  <plan_code>ac5_ct20_bt500_tm1_c0_p1005</plan_code>
+  <name>Custom Plan</name>
+  <unit_amount_in_cents>
+    <USD>1005</USD>
+    <EUR>854</EUR>
+    <GBP>754</GBP>
+  </unit_amount_in_cents>
+  <plan_interval_length>1</plan_interval_length>
+  <plan_interval_unit>months</plan_interval_unit>
+  <tax_code>digital</tax_code>
+  <success_url>https://buy.audiense.com/signup_done?plan={{plan_code}}</success_url>
+  <cancel_url>https://buy.audiense.com/signup_canceled</cancel_url>
+  <bypass_hosted_confirmation>true</bypass_hosted_confirmation>
+</plan>`;
+		const output = jsToXml(input, 'plan');
+		assert.equal(output, expected);
+	});
+
   it('should build an entire object correctly', () => {
 		const output = jsToXml(input());
 		assert.equal(output, expected());


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/AudienseCo/node-recurly/commit/ddb89db1fd04363625e933c0b6f2309bf6b919e3 that was adding `<root>` as the root of all XML params to write endpoints.