### PR TITLE
Fixes a callback called twice

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -23,14 +23,14 @@ exports.create = function(config){
           'Content-Length' : (data) ? data.length : 0
         }
       };
-      
+
       if(method.toLowerCase() == 'post' || method.toLowerCase() == 'put' ){
         options.headers['Content-Type'] = 'application/xml; charset=utf-8';
-        that.debug(data); 
+        that.debug(data);
       }
       that.debug(options);
       var req = https.request(options, function(res) {
-        
+
         var responsedata = '';
         res.on('data', function(d) {
           responsedata+=d;
@@ -58,7 +58,7 @@ exports.create = function(config){
               if(responsedata != ''){
                 parser.parseString(responsedata, function(err, result){
                   toreturn.data = result;
-                  callback(toreturn);
+                  process.nextTick(() => callback(toreturn));
                 });
               }
               else{
@@ -100,5 +100,5 @@ exports.create = function(config){
 
   }
 }
-	
+
 })();


### PR DESCRIPTION
We had a test failing because of an strange behaviour. The test was throwing an error, and because recurly client uses a `try ... catch ...` the error was being catch by this library. Wrapping the callback call if it has succeeded in a `process.nextTick` solves this issue.