### PR TITLE
Remove unnecessary try catch to avoid callbacks duplication

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -39,36 +39,30 @@ exports.create = function(config){
           responsedata = that.trim(responsedata);
           that.debug('Response is: ' + res.statusCode);
           that.debug(responsedata);
-          try{
-            var toreturn = {status: 'ok', data: '', headers: res.headers };
-            if((res.statusCode == 404) || (res.statusCode == 422) || (res.statusCode == 500) || (res.statusCode == 412)){
-              toreturn.status = 'error';
+          var toreturn = {status: 'ok', data: '', headers: res.headers };
+          if((res.statusCode == 404) || (res.statusCode == 422) || (res.statusCode == 500) || (res.statusCode == 412)){
+            toreturn.status = 'error';
+            parser.parseString(responsedata, function(err, result){
+              toreturn.data = result;
+              callback(toreturn);
+            });
+          }
+          else if(res.statusCode >= 400){
+            toreturn.status = 'error';
+            toreturn.data = res.statusCode;
+            toreturn.additional = responsedata;
+            callback(toreturn);
+          }
+          else{
+            if(responsedata != ''){
               parser.parseString(responsedata, function(err, result){
                 toreturn.data = result;
-                callback(toreturn);
+                process.nextTick(() => callback(toreturn));
               });
             }
-            else if(res.statusCode >= 400){
-              toreturn.status = 'error';
-              toreturn.data = res.statusCode;
-              toreturn.additional = responsedata;
-              callback(toreturn);
-            }
             else{
-              if(responsedata != ''){
-                parser.parseString(responsedata, function(err, result){
-                  toreturn.data = result;
-                  process.nextTick(() => callback(toreturn));
-                });
-              }
-              else{
-                callback({status: 'ok', description: res.statusCode });
-              }
+              callback({status: 'ok', description: res.statusCode });
             }
-            return;
-          }
-          catch(e){
-            return callback({status: 'error', description: e });
           }
         });
       });


### PR DESCRIPTION
The try catch that removes this PR seems unnecessary as there is no synchronous code inside. This try catch is catching all external errors in the context where Recurly methods are used and so two callbacks are triggered